### PR TITLE
Add information to README on how to update the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@ This repository is part of the [Find Case Law](https://caselaw.nationalarchives.
 
 This repository contains advice and notes to help the judiciary deliver judgments to the Find Case Law service.
 
+## Updating this guidance
+
+### Content
+
+All content for this guidance minisite is kept in the `content` folder as HTML files. These contain a very minimalistic `<head>` element with a `<title>`, and the content itself lives in the `<body>` element. You do not need to include any additional markup for the site layout such as header, menu or footers.
+
+### Menus
+
+The site's menus are defined in the `NAV_STRUCTURE` constant in `pelicanconf.py`
+
+### Templates
+
+Templates for this minisite (including overall page layout, header, menus and footer) are kept in the `theme/templates` folder.
+
+The bulk of the layout is defined in `base.html`. `page.html` provides additional behaviour around page titles.
+
 ## Deployment
 
 <!-- last_review: 2026-04-13 -->

--- a/theme/templates/page.html
+++ b/theme/templates/page.html
@@ -1,6 +1,8 @@
-{% extends "base.html" %} {% block html_lang %}{{ page.lang }}{% endblock %} {%
-block title %}{{ page.title|striptags }} &ndash; {{ SITENAME|striptags
-}}{%endblock%} {% block content %}
-<h1 class="mt-4">{{ page.title }}</h1>
+<!-- prettier-ignore -->
+{% extends "base.html" %}
+{% block html_lang %}{{ page.lang }}{% endblock html_lang %}
+{% block title %}{{ page.title|striptags }} &ndash; {{ SITENAME|striptags }}{% endblock title %}
 
-{{ page.content }} {% endblock %}
+{% block content %}
+<h1 class="mt-4">{{ page.title }}</h1>
+{{ page.content }} {% endblock content %}


### PR DESCRIPTION
Following the swap to Pelican to generate the site, bulk out the README with a bit of information on where things live.